### PR TITLE
Install missing dependencies

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,6 @@
+brew "bdw-gc"
 brew "crystal-lang"
 tap "f/guardian"
 brew "guardian"
 brew "hub" # used to publish releases on github
+brew "libyaml"


### PR DESCRIPTION
The compiled `mnd` cli app did not run without these two utilities and
these two utilities wasn't available on a new macbook
(tested this week with a new macbook)

PB-253 @MarLua 