### PR TITLE
Bail out with warning when attempting to install non existing repos

### DIFF
--- a/src/mnd/commands/install.cr
+++ b/src/mnd/commands/install.cr
@@ -6,8 +6,14 @@ module Mnd
     mnd install mynewsdesk # Only install mynewsdesk
     EOF
 
-
     def perform
+      if arguments.size != selected_repos.size
+        not_repos = arguments - selected_repos.map &.name
+        plural = not_repos.size > 1
+        display.error "Repo#{'s' if plural} not found: #{not_repos.join(", ")}"
+        return
+      end
+
       repos = selected_repos.presence || Repo.all
       uninstalled_repos = repos.reject &.exists?
 


### PR DESCRIPTION
Before fix `mnd install <some-misspelled-repo>` would result in all repos being installed.

After fix it will fail fast with some terminal output:
<img width="644" alt="screen shot 2018-09-03 at 16 41 19" src="https://user-images.githubusercontent.com/3461/44992664-38584980-af98-11e8-91db-58c32e2fcc75.png">

Note that initial code named things "apps" which I later changed to "repos" for consistency. That's why the screenshot is showing "App" rather than "Repo".