### PR TITLE
Rename lang-detector to mnd-langdetect

### DIFF
--- a/src/mnd/platforms.cr
+++ b/src/mnd/platforms.cr
@@ -4,7 +4,7 @@ module Mnd
       Repo.new("mynewsdesk", color: :cyan),
       Repo.new("social-media-monitor", color: :green),
       Repo.new("audience", color: :light_cyan, alias: "data"),
-      Repo.new("lang-detector", color: :light_yellow),
+      Repo.new("mnd-langdetect", color: :light_yellow),
       Repo.new("audience-api", color: :yellow),
       Repo.new("mnd-content-marketplace-backend", color: :yellow, alias: "content-marketplace-backend"),
       Repo.new("mnd-navigation", color: :yellow, alias: "navigation"),


### PR DESCRIPTION
Chose this since it already uses this name on Heroku