### PR TITLE
Fix “mnd update”

### DIFF
--- a/src/mnd/commands/update.cr
+++ b/src/mnd/commands/update.cr
@@ -3,12 +3,12 @@ require "http/client"
 module Mnd
   class Commands::Update < Commands::Base
     summary "Self update"
-    usage "mndx update # update itself reinstalling from HEAD"
+    usage "mnd update # update itself reinstalling from HEAD"
 
     def perform
       display.info "Updating mnd..."
 
-      run "brew reinstall --HEAD mynewsdesk/tap/mnd"
+      run "brew reinstall mnd"
     end
   end
 end


### PR DESCRIPTION
Running reinstall with the `--HEAD` option now raises `Error: invalid option: --HEAD`. Recommended.

Current `mnd` users need to manually run `brew reinstall mnd` to get the fixed version.