### PR TITLE
Check prerequisites on mnd setup

### DIFF
--- a/src/mnd/commands/setup.cr
+++ b/src/mnd/commands/setup.cr
@@ -4,6 +4,8 @@ module Mnd
     usage "mnd setup # runs step by step configuration"
 
     def perform
+      check_prerequisites!
+
       config = LocalConfig.instance
       default_path = config.root_path? || "~/code"
 
@@ -35,6 +37,40 @@ module Mnd
       config.persist!
 
       display.info "All done!"
+    end
+
+    private def check_prerequisites!
+      # enforce rbenv has been initialized
+      unless `which ruby`.includes?("rbenv")
+        display.error "ERROR: Looks like you haven't initialized rbenv properly."
+        display.error "Check out the 'Configure rbenv' section of the dev-computer README:"
+        display.error "https://github.com/mynewsdesk/dev-computer"
+        abort
+      end
+
+      # enforce heroku cli installed
+      unless system("which heroku > /dev/null")
+        display.error "ERROR: Looks like you haven't installed the heroku CLI."
+        display.error "Please run the dev-computer install script to install all prerequisites."
+        abort
+      end
+
+      # enforce heroku cli is logged in
+      unless system("heroku auth:whoami &> /dev/null")
+        display.error "ERROR: You are not logged in to heroku. Please run 'heroku login' to login."
+        abort
+      end
+
+      # enforce heroku access to mynewsdesk organization
+      unless `heroku orgs`.includes?("mynewsdesk")
+        display.error "ERROR: Your heroku user doesn't have access to the mynewsdesk organization."
+        display.error "Please ask your Team Lead or local DevOps dude to hook you up."
+        abort
+      end
+    end
+
+    private def abort
+      exit 1
     end
 
     private def yes?(prompt)


### PR DESCRIPTION
A common scenario when using `mnd` for the first time has been that the steps following running the dev-computer install script were ignored. This will help point the user in the right direction and avoid seemingly successful installations of repositories (ie. bundle is happily installing all gems but on the wrong version of ruby because rbenv isn't active).