### PR TITLE
Add deploy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Usage: mnd COMMAND [repo1 repo2] [command-specific-options]
 Type 'mnd help COMMAND' for details of each command
 
 Available commands:
+deploy          Deploy app to a server
 edit            Open repo source in editor
 help            Helps you out!
 install         Install missing repos

--- a/src/mnd/api/buildkite.cr
+++ b/src/mnd/api/buildkite.cr
@@ -42,11 +42,11 @@ module Mnd::Api
       JSON.parse(response.body)
     end
 
-    def self.ensure_buildkite_api_token!
+    private def self.ensure_buildkite_api_token!
       prompt_for_buildkite_api_token unless LocalConfig.instance.buildkite_api_token?
     end
 
-    def self.prompt_for_buildkite_api_token
+    private def self.prompt_for_buildkite_api_token
       Mnd.display.info "Please copy / paste the Buildkite user's API Token from 1password to continue."
 
       config = LocalConfig.instance

--- a/src/mnd/api/buildkite.cr
+++ b/src/mnd/api/buildkite.cr
@@ -1,0 +1,72 @@
+require "json"
+require "http/client"
+
+module Mnd::Api
+  module Buildkite
+    BASE_URL = "https://api.buildkite.com/v2"
+
+    def self.request(method, path, params = nil)
+      ensure_buildkite_api_token!
+
+      HTTP::Client.exec(
+        method,
+        "#{BASE_URL}/#{path}",
+        headers: HTTP::Headers{
+          "Authorization" => "Bearer #{LocalConfig.instance.buildkite_api_token}",
+          "Content-Type" => "application/json",
+          "Accept" => "application/json",
+        },
+        body: params ? params.to_json : nil,
+      )
+    end
+
+    def self.get_pipeline(pipeline_slug)
+      response = request("GET", "organizations/mynewsdesk/pipelines/#{pipeline_slug}")
+
+      JSON.parse(response.body)
+    end
+
+    def self.create_build(pipeline_slug, branch, deployment_target)
+      response = request(
+        "POST",
+        "organizations/mynewsdesk/pipelines/#{pipeline_slug}/builds",
+        params: {
+          commit: "HEAD",
+          branch: branch,
+          env: {
+            DEPLOYMENT_TARGET: deployment_target,
+          }
+        }
+      )
+
+      JSON.parse(response.body)
+    end
+
+    def self.ensure_buildkite_api_token!
+      prompt_for_buildkite_api_token unless LocalConfig.instance.buildkite_api_token?
+    end
+
+    def self.prompt_for_buildkite_api_token
+      Mnd.display.info "Please copy / paste the Buildkite user's API Token from 1password to continue."
+
+      config = LocalConfig.instance
+
+      print "Buildkite API Token: "
+      config.buildkite_api_token = gets.to_s.chomp
+
+      test_request_response = request("GET", "user")
+
+      if test_request_response.status_code == 200
+        config.persist!
+      else
+        Mnd.display.info ""
+        Mnd.display.error "You provided the API Token '#{config.buildkite_api_token}' but the request to Buildkite's API failed. Maybe you provided the wrong token?"
+        Mnd.display.error "The response from Buildkite's API had status '#{test_request_response.status_code}' and body:"
+        Mnd.display.error test_request_response.body
+        Mnd.display.info "Please run the command again to try again."
+
+        exit 1
+      end
+    end
+  end
+end

--- a/src/mnd/commands/deploy.cr
+++ b/src/mnd/commands/deploy.cr
@@ -1,0 +1,97 @@
+require "../api/buildkite"
+
+module Mnd
+  class Commands::Deploy < Commands::Base
+    summary "Deploy app to a server"
+    <<-EOF
+    mnd deploy # deploy current branch to a server (chosen interactively)
+    EOF
+
+    def perform
+      pipeline_slug = get_and_verify_deploy_pipeline_slug_from_path
+      branch = Mnd::Utils::Git.current_branch
+
+      Mnd::Utils::Git.verify_remote_branch_up_to_date!(branch)
+
+      display.info "Deploying the '#{branch}' branch..."
+
+      available_deployment_targets.each_with_index do |target, i|
+        display.info "#{i + 1}. #{target["label"]}"
+      end
+
+      if available_deployment_targets.size == 1
+        deployment_target = available_deployment_targets[0]
+      else
+        print "Where would you like to deploy? [1..#{available_deployment_targets.size}] "
+
+        answer = gets.to_s.to_i
+        deployment_target = available_deployment_targets[answer - 1]
+      end
+
+      display.info ""
+      display.info "You're about to deploy the branch '#{branch}' to '#{deployment_target["label"]}'."
+      print "Do you want to continue? [y/N] "
+
+      confirmation = gets.to_s
+
+      if confirmation[/^y/i]?
+        json = Api::Buildkite.create_build(
+          pipeline_slug: pipeline_slug,
+          branch: branch,
+          deployment_target: deployment_target["value"],
+        )
+
+        display.info ""
+        display.info "Deploy build created at Buildkite:"
+        display.info json["web_url"]
+      else
+        display.info "Aborted."
+        exit
+      end
+    end
+
+    private def get_and_verify_deploy_pipeline_slug_from_path
+      current_dir = `pwd`.chomp.split("/").last
+      pipeline_slug = "#{current_dir}-deploy"
+
+      json = Api::Buildkite.get_pipeline(pipeline_slug)
+
+      if json["slug"]?
+        json["slug"]
+      else
+        display.error "Error: It appears your current working directory doesn't correspond with a Buildkite deploy pipeline (looked for '#{pipeline_slug}' but found nothing)"
+        exit 1
+      end
+    end
+
+    private def available_deployment_targets
+      unless File.exists?(".buildkite/pipeline.yml")
+        display.error "Error: couldn't find a .buildkite/pipeline.yml file. Is this repo deployable?"
+        exit 1
+      end
+
+      pipeline_yaml = File.read(".buildkite/pipeline.yml")
+      pipeline = YAML.parse(pipeline_yaml)
+
+      field = deployment_target_field(pipeline)
+
+      if field
+        field["options"].as_a
+      else
+        display.error "Error: couldn't find a deployment-target field in .buildkite/pipeline.yml. Is this repo deployable?"
+        exit 1
+      end
+    end
+
+    private def deployment_target_field(pipeline)
+      pipeline["steps"].as_a.each do |step|
+        next if step.raw.is_a? String # "wait" step is a plain String
+
+        step = step.as_h
+        step.has_key?("fields") && step["fields"].as_a.each do |field|
+          return field if field["key"] == "deployment-target"
+        end
+      end
+    end
+  end
+end

--- a/src/mnd/local_config.cr
+++ b/src/mnd/local_config.cr
@@ -42,6 +42,18 @@ module Mnd
       @config["root_path"] = root
     end
 
+    def buildkite_api_token?
+      @config["buildkite_api_token"]?
+    end
+
+    def buildkite_api_token
+      @config["buildkite_api_token"]
+    end
+
+    def buildkite_api_token=(buildkite_api_token)
+      @config["buildkite_api_token"] = buildkite_api_token
+    end
+
     def persist!
       File.write DOT_FILE_PATH, @config.to_yaml
     end

--- a/src/mnd/utils/git.cr
+++ b/src/mnd/utils/git.cr
@@ -20,8 +20,36 @@ module Mnd::Utils
         Mnd.display.error dirty_repos.map(&.to_s).join("\n")
         Mnd.display.error "Please stash changes and run command again"
 
-        exit
+        exit 1
       end
+    end
+
+    # Assuming we're inside a git repo this will match a local branch name with
+    # branches on the default remote server to ensure they're up to date.
+    def self.verify_remote_branch_up_to_date!(branch)
+      # Example STDOUT of ls-remote:
+      # 867907262d623e3632b41808617bee5f9c5ac2d2  refs/heads/<branch-name>
+      # 8b4428eb9db3e679da599bb580706e6828eecee9  refs/heads/master
+      remote_info = `git ls-remote --heads | grep -e "heads/#{branch}$"`.chomp
+
+      if remote_info.empty?
+        Mnd.display.error "Error: The branch '#{branch}' doesn't exist in the remote git repo. Run 'git push' on the branch and try again."
+        exit 1
+      else
+        remote_sha = remote_info.split(/\s/).first
+        local_sha = `git rev-parse #{branch}`.chomp
+
+        unless remote_sha == local_sha
+          Mnd.display.error "Error: Your local '#{branch}' branch doesn't appear to be up to be in sync with the remote branch. Did you forget to 'git push' or 'git pull --rebase'?"
+          exit 1
+        end
+      end
+    end
+
+    # String with current branch or nil if not inside a git repo
+    def self.current_branch
+      # Would love to use 'git branch --show-current' instead but would silently fail on Git version < 2.22
+      `git rev-parse --abbrev-ref HEAD`.chomp.presence
     end
   end
 end


### PR DESCRIPTION
Allows creating builds on our deploy pipelines without going through the Buildkite UI.

This will create a build no matter the status of test builds etc so it restores the lost functionality of deploying in progress or broken builds that we previously had access to via SemaphoreCI.

The command works based on terminal context. It will assume that you want to deploy the git repo in your path using the currently checked out branch. Deployment target (ie. `mnd-staging` or `mnd-funnel` etc) are chosen interactively.

The tool also makes a few sanity checks on your branch before deploying:
- Ensure remote branch exists (to avoid broken buildkite build due to not finding the branch)
- Ensure remote branch is up to date with local branch (to avoid accidentally deploying an out of date remote branch)

Example:
![mnd-deploy](https://user-images.githubusercontent.com/3461/70058590-7bf89380-15df-11ea-8cb2-79cbcabe6101.gif)
