### PR TITLE
Allow mnd deploy to be used without access to git repo

### DIFF
--- a/src/mnd/api/buildkite.cr
+++ b/src/mnd/api/buildkite.cr
@@ -47,7 +47,7 @@ module Mnd::Api
     end
 
     private def self.prompt_for_buildkite_api_token
-      Mnd.display.info "Please copy / paste the Buildkite user's API Token from 1password to continue."
+      Mnd.display.info "Please copy / paste the Buildkite user's API Token from 1password to continue. If you have a personal account on Buildkite generate your own token at https://buildkite.com/user/api-access-tokens with the scopes read_builds, write_builds, read_pipelines, read_user instead."
 
       config = LocalConfig.instance
 

--- a/src/mnd/commands/deploy.cr
+++ b/src/mnd/commands/deploy.cr
@@ -4,19 +4,36 @@ module Mnd
   class Commands::Deploy < Commands::Base
     summary "Deploy app to a server"
     usage <<-EOF
+    Recommended usage of mnd deploy assumes that your working directory is the repo to be deployed:
     mnd deploy # deploy current branch to a server (chosen interactively)
     mnd deploy <deployment-target> # deploy current branch to the target (eg. mnd-staging)
+
+    If you don't have local access to the github repo you may deploy like this instead:
+    mnd deploy <repo> <branch> <deployment-target>
     EOF
 
     def perform
-      pipeline_slug = get_and_verify_deploy_pipeline_slug_from_path
-      branch = Mnd::Utils::Git.current_branch
+      # The triple argument version is meant to be used without local access to the git repo,
+      # originally conceived for QA consultants not employed at mynewsdesk. It is more brittle
+      # than normal usage since we're unable to validate input to the same extent.
+      if arguments.size == 3
+        repo, branch, deployment_target_argument = arguments
+        pipeline_slug = "#{repo}-deploy"
+        verify_pipeline_exists! pipeline_slug
 
-      Mnd::Utils::Git.verify_remote_branch_up_to_date!(branch)
+        deployment_target = { "label" => deployment_target_argument, "value" => deployment_target_argument }
+      else
+        pipeline_slug = deploy_pipeline_slug_from_path
+        branch = Mnd::Utils::Git.current_branch
+        verify_pipeline_exists! pipeline_slug
+        Mnd::Utils::Git.verify_remote_branch_up_to_date!(branch)
+
+        deployment_target_argument = arguments[0] if arguments.size == 1
+
+        deployment_target = find_or_prompt_for_deployment_target(deployment_target_argument)
+      end
 
       display.info "Deploying the '#{branch}' branch..."
-
-      deployment_target = find_or_prompt_for_deployment_target
 
       display.info ""
       display.info "You're about to deploy the branch '#{branch}' to '#{deployment_target["label"]}'."
@@ -40,22 +57,23 @@ module Mnd
       end
     end
 
-    private def get_and_verify_deploy_pipeline_slug_from_path
+    private def deploy_pipeline_slug_from_path
       current_dir = `pwd`.chomp.split("/").last
-      pipeline_slug = "#{current_dir}-deploy"
+      "#{current_dir}-deploy"
+    end
 
+    private def verify_pipeline_exists!(pipeline_slug)
       json = Api::Buildkite.get_pipeline(pipeline_slug)
 
       if json["slug"]?
         json["slug"]
       else
-        display.error "Error: It appears your current working directory doesn't correspond with a Buildkite deploy pipeline (looked for '#{pipeline_slug}' but found nothing)"
+        display.error "Error: It appears your repository doesn't correspond with a Buildkite deploy pipeline (looked for '#{pipeline_slug}' but found nothing)"
         exit 1
       end
     end
 
-    private def find_or_prompt_for_deployment_target
-      deployment_target_argument = arguments.first?
+    private def find_or_prompt_for_deployment_target(deployment_target_argument : String?)
       available_deployment_targets = read_deployment_targets_from_pipeline_yml
 
       if deployment_target_argument


### PR DESCRIPTION
This is an edge case created to allow Vladimir to deploy even though he doesn't have access to our github repos.

Would of course be preferable if Vladimir was a proper Mynewsdesk employee and had the same system setup as everyone else but that's not an option at the moment :(