### PR TITLE
Add mnd-notifications

### DIFF
--- a/src/mnd/platforms.cr
+++ b/src/mnd/platforms.cr
@@ -5,6 +5,7 @@ module Mnd
       Repo.new("mnd-audience", color: :light_cyan, alias: "audience"),
       Repo.new("mnd-events-api", color: :yellow, alias: "events-api"),
       Repo.new("mnd-langdetect", color: :light_yellow, alias: "langdetect"),
+      Repo.new("mnd-notifications", color: :light_green, alias: "notifications"),
       Repo.new("mnd-publish-frontend", color: :yellow, alias: "publish-frontend"),
       Repo.new("mnd-reader-frontend", color: :pink, alias: "reader-frontend"),
       Repo.new("mnd-track-backend", color: :light_red, alias: "track-backend"),


### PR DESCRIPTION
`mnd-notifications` has been converted to a Rails app which can be run in our dev environments like all the other apps. Rejoice!